### PR TITLE
Working towards CUDA use with NCCL backend

### DIFF
--- a/assert_cuda.py
+++ b/assert_cuda.py
@@ -1,0 +1,153 @@
+import os
+from math import ceil
+from copy import deepcopy
+
+import torch
+import torch.multiprocessing as mp
+import torch.distributed as dist
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+from ring_attention_pytorch.ring_attention import RingTransformer
+from ring_attention_pytorch.distributed import all_gather_variable_dim
+
+
+def setup(rank, world_size, use_cuda):
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = "12355"
+    if use_cuda:
+        dist.init_process_group("nccl", rank=rank, world_size=world_size)
+        torch.cuda.set_device(rank)
+    else:
+        dist.init_process_group("gloo", rank=rank, world_size=world_size)
+
+
+def cleanup():
+    dist.destroy_process_group()
+
+
+def start(
+    rank,
+    world_size,
+    batch_size,
+    batch_size_var_len,
+    seq_len,
+    num_sharded_batches,
+    causal,
+    striped_ring_attn,
+    dim,
+    use_cuda,
+):
+    setup(rank, world_size, use_cuda)
+
+    ring_seq_size = ceil(seq_len / world_size) * num_sharded_batches
+    bucket_size = ring_seq_size // 2
+
+    ring_attention_net = RingTransformer(
+        num_tokens=256,
+        dim=dim,
+        causal=causal,
+        depth=2,
+        dim_head=8,
+        ring_attn=True,
+        striped_ring_attn=striped_ring_attn,
+        ring_seq_size=ring_seq_size,
+        bucket_size=bucket_size,
+    )
+
+    flash_attention_net = RingTransformer(
+        num_tokens=256,
+        dim=dim,
+        causal=causal,
+        depth=2,
+        dim_head=8,
+        ring_attn=False,
+        bucket_size=bucket_size,
+    )
+
+    flash_attention_net.load_state_dict(ring_attention_net.state_dict())
+
+    if batch_size_var_len:
+        batch_size = batch_size + rank
+
+    seq = torch.randint(0, 256, (batch_size, seq_len))
+
+    # wrap
+
+    if use_cuda:
+        seq = seq.cuda(rank)
+        flash_attention_net.cuda(rank)
+        ring_attention_net.cuda(rank)
+
+    ddp_ring_attention_net = DDP(ring_attention_net)
+    ddp_flash_attention_net = DDP(flash_attention_net)
+
+    # flash
+
+    flash_out = ddp_flash_attention_net(seq)
+
+    flash_out.mean().backward()
+
+    # ring
+
+    ring_out = ddp_ring_attention_net(seq)
+
+    ring_out.mean().backward()
+
+    # validate output is the same for sequence split across machines vs without
+
+    if rank == 0:
+
+        ring_attention_net = ring_attention_net.cpu()
+        flash_attention_net = flash_attention_net.cpu()
+        ring_out = ring_out.cpu()
+        flash_out = flash_out.cpu()
+
+        assert torch.allclose(ring_out, flash_out, atol=1e-6), "output is not the same"
+
+        # validate gradients of token embedding is the same for ring vs non-ring
+
+        get_embed_grad = lambda model: model.token_emb.weight.grad
+        ring_embed_grad = get_embed_grad(ring_attention_net)
+        flash_embed_grad = get_embed_grad(flash_attention_net)
+
+        assert torch.allclose(
+            ring_embed_grad, flash_embed_grad, atol=1e-2
+        ), "grad is not the same"
+
+        print(
+            "✅ outputs and gradients are same between ring attention and non-ring attention"
+        )
+
+    cleanup()
+
+
+if __name__ == "__main__":
+    world_size = 8
+    batch_size = 2
+    num_sharded_batches = 1
+    batch_size_var_len = False
+    use_cuda = True
+    causal = True
+    striped_ring_attn = True
+
+    assert not use_cuda or torch.cuda.device_count() <= world_size
+
+    seq_len = 31
+    dim = 8
+
+    mp.spawn(
+        start,
+        args=(
+            world_size,
+            batch_size,
+            batch_size_var_len,
+            seq_len,
+            num_sharded_batches,
+            causal,
+            striped_ring_attn,
+            dim,
+            use_cuda,
+        ),
+        nprocs=world_size,
+        join=True,
+    )

--- a/ring_attention_pytorch/ring.py
+++ b/ring_attention_pytorch/ring.py
@@ -11,73 +11,96 @@ import torch.distributed as dist
 
 # helper functions
 
+
 def exists(v):
     return v is not None
+
 
 def default(v, d):
     return v if exists(v) else d
 
-def cast_tuple(t, length = 1):
+
+def cast_tuple(t, length=1):
     return t if isinstance(t, tuple) else ((t,) * length)
 
-cache = partial(lru_cache, maxsize = None)
+
+cache = partial(lru_cache, maxsize=None)
 
 # distributed globals
+
 
 @cache()
 def get_rank():
     return dist.get_rank() if dist.is_initialized() else 0
 
+
 @cache()
 def get_world_size():
     return dist.get_world_size() if dist.is_initialized() else 1
+
 
 @cache()
 def is_distributed():
     return dist.is_initialized() and dist.get_world_size() > 1
 
+
 # ring functions
 
-def circular_index_left(pos, ring_size, num = 1):
+
+def circular_index_left(pos, ring_size, num=1):
     return ((pos - num) + ring_size) % ring_size
 
-def circular_index_right(pos, ring_size, num = 1):
+
+def circular_index_right(pos, ring_size, num=1):
     return (pos + num) % ring_size
+
 
 # distributed ring
 
-def circular_rank_left(rank = None, ring_size = None, num = 1):
+
+def circular_rank_left(rank=None, ring_size=None, num=1):
     rank = default(rank, get_rank())
     ring_size = default(ring_size, get_world_size())
     ring_set_num = rank // ring_size
     offset = ring_set_num * ring_size
     return circular_index_left(rank, ring_size, num) + offset
 
-def circular_rank_right(rank = None, ring_size = None, num = 1):
+
+def circular_rank_right(rank=None, ring_size=None, num=1):
     rank = default(rank, get_rank())
     ring_size = default(ring_size, get_world_size())
     ring_set_num = rank // ring_size
     offset = ring_set_num * ring_size
     return circular_index_right(rank, ring_size, num) + offset
 
+
 # one ring pass
 
-def send_and_receive_(x, receive_buffer, send_to_rank, receive_from_rank):
-    send_op = dist.P2POp(dist.isend, x, send_to_rank)
-    recv_op = dist.P2POp(dist.irecv, receive_buffer, receive_from_rank)
+def send_and_receive_(
+    x, receive_buffer, send_to_rank, receive_from_rank, batched_p2p=True
+):
 
-    reqs = dist.batch_isend_irecv([send_op, recv_op])
+    if batched_p2p:
+        send_op = dist.P2POp(dist.isend, x, send_to_rank)
+        recv_op = dist.P2POp(dist.irecv, receive_buffer, receive_from_rank)
 
-    for req in reqs:
-        req.wait()
+        reqs = dist.batch_isend_irecv([send_op, recv_op])
 
-    dist.barrier()
+        for req in reqs:
+            req.wait()
+        dist.barrier()
+    else:
+        send_request = dist.isend(x, send_to_rank)
+        dist.recv(receive_buffer, receive_from_rank)
+
+        send_request.wait()
+        dist.barrier()
 
 def ring_pass(
     num_ring_passes: int,
     x: Tensor,
     receive_buffer: Optional[Tensor] = None,
-    ring_size: Optional[int] = None
+    ring_size: Optional[int] = None,
 ):
     ring_size = default(ring_size, get_world_size())
     x = x.contiguous()
@@ -87,19 +110,27 @@ def ring_pass(
     else:
         receive_buffer = receive_buffer.contiguous()
 
-    send_and_receive_(x, receive_buffer, circular_rank_right(ring_size = ring_size), circular_rank_left(ring_size = ring_size))
+    send_and_receive_(
+        x,
+        receive_buffer,
+        circular_rank_right(ring_size=ring_size),
+        circular_rank_left(ring_size=ring_size),
+    )
     return receive_buffer, x
+
 
 one_ring_pass = partial(ring_pass, 1)
 
 # iterator for all ring passes of all tensors
 
-RingInfo = namedtuple('RingInfo', ['ring_rank', 'is_last'])
+RingInfo = namedtuple("RingInfo", ["ring_rank", "is_last"])
 
-def null_ring_pass(*tensors, max_iters = None, receive_buffers = None, ring_size = None):
+
+def null_ring_pass(*tensors, max_iters=None, receive_buffers=None, ring_size=None):
     yield RingInfo(0, True), (tensors, receive_buffers)
 
-def all_ring_pass(*tensors, max_iters = None, receive_buffers = None, ring_size = None):
+
+def all_ring_pass(*tensors, max_iters=None, receive_buffers=None, ring_size=None):
     ring_size = default(ring_size, get_world_size())
     max_iters = default(max_iters, ring_size)
 
@@ -126,7 +157,9 @@ def all_ring_pass(*tensors, max_iters = None, receive_buffers = None, ring_size 
 
         for tensor, receive_buffer in zip(tensors, receive_buffers):
             if exists(tensor):
-                new_tensor, new_receive_buffer = one_ring_pass(tensor, receive_buffer, ring_size)
+                new_tensor, new_receive_buffer = one_ring_pass(
+                    tensor, receive_buffer, ring_size
+                )
             else:
                 new_tensor, new_receive_buffer = None, None
 

--- a/ring_attention_pytorch/ring_attention.py
+++ b/ring_attention_pytorch/ring_attention.py
@@ -15,38 +15,34 @@ from ring_attention_pytorch.ring import (
     all_ring_pass,
     is_distributed,
     get_rank,
-    get_world_size
+    get_world_size,
 )
 
-from ring_attention_pytorch.ring_flash_attention import (
-    ring_flash_attn
-)
+from ring_attention_pytorch.ring_flash_attention import ring_flash_attn
 
-from ring_attention_pytorch.distributed import (
-    split_by_rank,
-    AllGather
-)
+from ring_attention_pytorch.distributed import split_by_rank, AllGather
 
 # helper functions
+
 
 def exists(v):
     return v is not None
 
+
 def default(v, d):
     return v if exists(v) else d
 
-def cast_tuple(t, length = 1):
+
+def cast_tuple(t, length=1):
     return t if isinstance(t, tuple) else ((t,) * length)
+
 
 def divisible_by(num, den):
     return (num % den) == 0
 
+
 def default_attention(
-    q: Tensor,
-    k: Tensor,
-    v: Tensor,
-    mask: Optional[Tensor] = None,
-    causal: bool = False
+    q: Tensor, k: Tensor, v: Tensor, mask: Optional[Tensor] = None, causal: bool = False
 ):
     q = q * (q.shape[-1] ** -0.5)
 
@@ -54,29 +50,31 @@ def default_attention(
 
     # similarity
 
-    sim = einsum('b i h d, b j h d -> b h i j', q, k)
+    sim = einsum("b i h d, b j h d -> b h i j", q, k)
 
     # masking
 
     if causal:
         i, j = sim.shape[-2:]
-        causal_mask = torch.ones((i, j), dtype = torch.bool).triu(j - i + 1)
+        causal_mask = torch.ones((i, j), dtype=torch.bool).triu(j - i + 1)
         sim = torch.where(causal_mask, mask_value, sim)
 
     elif exists(mask):
-        sim = einx.where('b j, b h i j, -> b h i j', mask, sim, mask_value)
+        sim = einx.where("b j, b h i j, -> b h i j", mask, sim, mask_value)
 
     # attend
 
-    attn = einx.softmax('b h i [j]', sim)
+    attn = einx.softmax("b h i [j]", sim)
 
     # aggregate
 
-    out = einsum('b h i j, b j h d -> b i h d', attn, v)
+    out = einsum("b h i j, b j h d -> b i h d", attn, v)
 
     return out
 
+
 # rotary embeddings with modifications to support striped attention
+
 
 class RingRotaryEmbedding(Module):
     def __init__(
@@ -84,8 +82,8 @@ class RingRotaryEmbedding(Module):
         dim,
         ring: bool = False,
         striped: bool = False,
-        buckets: int = 1,        # in striped attention with flash buckets > 1, one needs to specify the number of buckets per machine
-        theta = 10000
+        buckets: int = 1,  # in striped attention with flash buckets > 1, one needs to specify the number of buckets per machine
+        theta=10000,
     ):
         super().__init__()
         self.ring = ring
@@ -93,18 +91,14 @@ class RingRotaryEmbedding(Module):
         self.buckets = buckets
 
         inv_freq = theta ** -(torch.arange(0, dim, 2).float() / dim)
-        self.register_buffer('inv_freq', inv_freq)
+        self.register_buffer("inv_freq", inv_freq)
 
     @property
     def device(self):
         return self.inv_freq.device
 
-    @autocast(enabled = False)
-    def forward(
-        self,
-        seq_len: int,
-        offset = 0
-    ):
+    @autocast(enabled=False)
+    def forward(self, seq_len: int, offset=0):
         device = self.device
         pos = None
 
@@ -114,39 +108,39 @@ class RingRotaryEmbedding(Module):
                 ring_stride = get_world_size() * buckets
                 ring_offset = buckets
 
-                pos = torch.arange(seq_len // buckets, device = device)
-                pos = rearrange('n -> n b', pos, b = buckets)
+                pos = torch.arange(seq_len // buckets, device=device)
+                pos = rearrange("n -> n b", pos, b=buckets)
 
                 pos = pos * ring_stride
-                pos += torch.arange(buckets, device = device) + (get_rank() * buckets)
-                pos = rearrange('n b -> (b n)', pos)
+                pos += torch.arange(buckets, device=device) + (get_rank() * buckets)
+                pos = rearrange("n b -> (b n)", pos)
 
             else:
-                pos = torch.arange(seq_len, device = device)
+                pos = torch.arange(seq_len, device=device)
                 pos += seq_len * get_rank()
         else:
-            pos = torch.arange(seq_len, device = device)
+            pos = torch.arange(seq_len, device=device)
 
         pos = pos.type_as(self.inv_freq)
-        freqs = torch.einsum('i , j -> i j', pos, self.inv_freq)
-        return torch.cat((freqs, freqs), dim = -1)
+        freqs = torch.einsum("i , j -> i j", pos, self.inv_freq)
+        return torch.cat((freqs, freqs), dim=-1)
+
 
 def rotate_half(x):
-    x1, x2 = x.chunk(2, dim = -1)
+    x1, x2 = x.chunk(2, dim=-1)
     return torch.cat((-x2, x1), dim=-1)
 
-@autocast(enabled = False)
+
+@autocast(enabled=False)
 def apply_rotary_pos_emb(pos, t):
-    pos = rearrange('n d -> n 1 d', pos)
+    pos = rearrange("n d -> n 1 d", pos)
     return t * pos.cos() + rotate_half(t) * pos.sin()
+
 
 # batch to sequence sharding and back
 
-def pad_to_multiple(
-    x: Tensor,
-    length: int,
-    pad_value = 0
-):
+
+def pad_to_multiple(x: Tensor, length: int, pad_value=0):
     seq_len = x.shape[-1]
     remainder = seq_len % length
 
@@ -154,13 +148,10 @@ def pad_to_multiple(
         return x, 0
 
     pad_length = length - remainder
-    return F.pad(x, (0, pad_length), value = pad_value), pad_length
+    return F.pad(x, (0, pad_length), value=pad_value), pad_length
 
-def maybe_pad_seq_and_mask(
-    x: Tensor,
-    mask: Optional[Tensor],
-    seq_size: int
-):
+
+def maybe_pad_seq_and_mask(x: Tensor, mask: Optional[Tensor], seq_size: int):
     orig_x, seq_len = x, x.shape[-1]
 
     # auto pad sequence and mask, as ring passing makes assumption tensor is all same shape
@@ -173,20 +164,17 @@ def maybe_pad_seq_and_mask(
     if not exists(mask):
         mask = torch.ones_like(orig_x).bool()
 
-    mask, _ = pad_to_multiple(mask, seq_size, pad_value = False)
+    mask, _ = pad_to_multiple(mask, seq_size, pad_value=False)
 
     return x, mask
 
-def sharded_batch_to_sharded_seq(
-    x: Tensor,
-    mask: Optional[Tensor],
-    seq_size: int
-):
+
+def sharded_batch_to_sharded_seq(x: Tensor, mask: Optional[Tensor], seq_size: int):
     assert is_distributed()
 
     # all gather across batch
 
-    all_gather = AllGather(dim = 0)
+    all_gather = AllGather(dim=0)
 
     x, sizes = all_gather(x)
 
@@ -203,39 +191,38 @@ def sharded_batch_to_sharded_seq(
 
     num_sharded_batches = world_size // total_split_seq
 
-    x = rearrange('(b s) n -> b (s n)', x, s = num_sharded_batches)
+    x = rearrange("(b s) n -> b (s n)", x, s=num_sharded_batches)
 
     # then split sequence across machines
 
-    x = x.split(seq_size, dim = -1)
+    x = x.split(seq_size, dim=-1)
 
     x, _ = split_by_rank(x)
 
     if exists(mask):
-        mask = rearrange('(b s) n -> b (s n)', mask, s = num_sharded_batches)
-        mask = mask.split(seq_size, dim = -1)
+        mask = rearrange("(b s) n -> b (s n)", mask, s=num_sharded_batches)
+        mask = mask.split(seq_size, dim=-1)
         mask, _ = split_by_rank(mask)
 
     return (x, mask), sizes, num_sharded_batches
 
-def sharded_seq_to_sharded_batch(
-    logits: Tensor,
-    sizes,
-    num_sharded_batches = 1
-):
-    all_gather = AllGather(dim = -2) # all gather across sequence
+
+def sharded_seq_to_sharded_batch(logits: Tensor, sizes, num_sharded_batches=1):
+    all_gather = AllGather(dim=-2)  # all gather across sequence
 
     logits, _ = all_gather(logits)
 
-    logits = rearrange('b (s n) c -> (b s) n c', logits, s = num_sharded_batches)
+    logits = rearrange("b (s n) c -> (b s) n c", logits, s=num_sharded_batches)
 
-    logits = logits.split(sizes.tolist(), dim = 0)
+    logits = logits.split(sizes.tolist(), dim=0)
 
     logits, _ = split_by_rank(logits)
 
     return logits
 
+
 # main class
+
 
 class RingAttention(Module):
     @beartype
@@ -262,7 +249,7 @@ class RingAttention(Module):
         super().__init__()
         self.eps = eps
         self.heads = heads
-        self.scale = dim_head ** -0.5
+        self.scale = dim_head**-0.5
         self.causal = causal
 
         assert divisible_by(ring_seq_size, bucket_size)
@@ -272,7 +259,9 @@ class RingAttention(Module):
         self.striped_ring_attn = striped_ring_attn
 
         self.force_regular_attn = force_regular_attn
-        self.auto_shard_seq = default(auto_shard_seq, ring_attn) # this should be done at the transformer level on the token ids for efficiency, but for testing purposes
+        self.auto_shard_seq = default(
+            auto_shard_seq, ring_attn
+        )  # this should be done at the transformer level on the token ids for efficiency, but for testing purposes
 
         assert not (not self.ring_attn and self.auto_shard_seq)
 
@@ -284,11 +273,11 @@ class RingAttention(Module):
         self.rotary_embed = None
         if rotary_embed:
             self.rotary_embed = RingRotaryEmbedding(
-                dim = dim_head,
-                ring = ring_attn,
-                striped = striped_ring_attn,
-                theta = rotary_embed_theta,
-                buckets = ring_seq_size // bucket_size
+                dim=dim_head,
+                ring=ring_attn,
+                striped=striped_ring_attn,
+                theta=rotary_embed_theta,
+                buckets=ring_seq_size // bucket_size,
             )
 
         # projections
@@ -297,10 +286,10 @@ class RingAttention(Module):
 
         self.to_qkv = nn.Sequential(
             RMSNorm(dim) if prenorm else nn.Identity(),
-            nn.Linear(dim, dim_inner * 3, bias = False)
+            nn.Linear(dim, dim_inner * 3, bias=False),
         )
 
-        self.to_out = nn.Linear(dim_inner, dim, bias = False)
+        self.to_out = nn.Linear(dim_inner, dim, bias=False)
 
         # whether to use flash attention cuda kernel
 
@@ -310,10 +299,10 @@ class RingAttention(Module):
     def forward(
         self,
         x,
-        mask = None,
-        rotary_emb = None,
-        force_ring_reduce_off = False,
-        ring_size = None,
+        mask=None,
+        rotary_emb=None,
+        force_ring_reduce_off=False,
+        ring_size=None,
     ):
         """
         einstein notation
@@ -334,17 +323,19 @@ class RingAttention(Module):
             x, mask = maybe_pad_seq_and_mask(x, mask, self.ring_seq_size)
 
             if self.striped_ring_attn:
-                x = rearrange('b (i j) d -> b (j i) d', x, i = self.bucket_size)
+                x = rearrange("b (i j) d -> b (j i) d", x, i=self.bucket_size)
 
                 if exists(mask):
-                    mask = rearrange('b (i j) -> b (j i)', mask, i = self.bucket_size)
+                    mask = rearrange("b (i j) -> b (j i)", mask, i=self.bucket_size)
 
-            (x, mask), batch_sizes = sharded_batch_to_sharded_seq(x, mask, self.ring_seq_size)
+            (x, mask), batch_sizes = sharded_batch_to_sharded_seq(
+                x, mask, self.ring_seq_size
+            )
 
         device = x.device
 
         qkv = self.to_qkv(x)
-        q, k, v = rearrange('b n (qkv h d) -> qkv b n h d', qkv, qkv = 3, h = self.heads)
+        q, k, v = rearrange("b n (qkv h d) -> qkv b n h d", qkv, qkv=3, h=self.heads)
 
         # rotary relative positions
 
@@ -360,37 +351,43 @@ class RingAttention(Module):
         any_cuda_inputs = any([t.is_cuda for t in (q, k, v)])
 
         if self.force_regular_attn:
-            out = default_attention(q, k, v, mask = mask, causal = self.causal)
+            out = default_attention(q, k, v, mask=mask, causal=self.causal)
 
         elif any_cuda_inputs and self.use_cuda_kernel:
-            from ring_attention_pytorch.ring_flash_attention_cuda import ring_flash_attn_cuda
+            from ring_attention_pytorch.ring_flash_attention_cuda import (
+                ring_flash_attn_cuda,
+            )
 
             out = ring_flash_attn_cuda(
-                q, k, v,
+                q,
+                k,
+                v,
                 mask,
                 self.causal,
                 self.bucket_size,
                 ring_attn and not force_ring_reduce_off,
                 self.striped_ring_attn and not force_ring_reduce_off,
                 self.max_lookback_seq_len,
-                ring_size
+                ring_size,
             )
 
         else:
             out = ring_flash_attn(
-                q, k, v,
+                q,
+                k,
+                v,
                 mask,
                 self.causal,
                 self.bucket_size,
                 ring_attn and not force_ring_reduce_off,
                 self.striped_ring_attn and not force_ring_reduce_off,
                 self.max_lookback_seq_len,
-                ring_size
+                ring_size,
             )
 
         # combine heads
 
-        out = rearrange('b n h d -> b n (h d)', out)
+        out = rearrange("b n h d -> b n (h d)", out)
         out = self.to_out(out)
 
         if auto_shard_seq:
@@ -399,25 +396,26 @@ class RingAttention(Module):
 
         return out
 
+
 # simple transformer for end2end testing
+
 
 class RMSNorm(Module):
     def __init__(self, dim):
         super().__init__()
-        self.scale = dim ** 0.5
+        self.scale = dim**0.5
         self.gamma = nn.Parameter(torch.ones(dim))
 
     def forward(self, x):
-        return F.normalize(x, dim = -1) * self.scale * self.gamma
+        return F.normalize(x, dim=-1) * self.scale * self.gamma
 
-def FeedForward(dim, mult = 4):
+
+def FeedForward(dim, mult=4):
     dim_inner = int(dim * mult)
     return nn.Sequential(
-        RMSNorm(dim),
-        nn.Linear(dim, dim_inner),
-        nn.GELU(),
-        nn.Linear(dim_inner, dim)
+        RMSNorm(dim), nn.Linear(dim, dim_inner), nn.GELU(), nn.Linear(dim_inner, dim)
     )
+
 
 class RingTransformer(Module):
     @beartype
@@ -437,7 +435,7 @@ class RingTransformer(Module):
         ring_seq_size: int = 512,
         auto_shard_seq: Optional[bool] = None,
         max_lookback_seq_len: Optional[Union[Tuple[int, ...], int]] = None,
-        rotary_embed_theta: int = 10000,    # will need to be changed for the million token context
+        rotary_embed_theta: int = 10000,  # will need to be changed for the million token context
         ignore_index: int = -1
     ):
         super().__init__()
@@ -448,20 +446,24 @@ class RingTransformer(Module):
         self.bucket_size = bucket_size
         assert divisible_by(ring_seq_size, bucket_size)
 
-        self.auto_shard_seq = default(auto_shard_seq, ring_attn) # if ring attention is turned on, auto-shard across sequence dimension. this can also be turned off and done manually elsewhere in the data loading
+        self.auto_shard_seq = default(
+            auto_shard_seq, ring_attn
+        )  # if ring attention is turned on, auto-shard across sequence dimension. this can also be turned off and done manually elsewhere in the data loading
 
         assert not (not self.ring_attn and self.auto_shard_seq)
         assert not (not self.ring_attn and self.striped_ring_attn)
-        assert not (self.striped_ring_attn and not causal), 'striped ring attention only applies to autoregressive models'
+        assert not (
+            self.striped_ring_attn and not causal
+        ), "striped ring attention only applies to autoregressive models"
 
         self.token_emb = nn.Embedding(num_tokens, dim)
 
         self.rotary_emb = RingRotaryEmbedding(
-            dim = dim_head,
-            ring = ring_attn,
-            striped = striped_ring_attn,
-            theta = rotary_embed_theta,
-            buckets = ring_seq_size // bucket_size
+            dim=dim_head,
+            ring=ring_attn,
+            striped=striped_ring_attn,
+            theta=rotary_embed_theta,
+            buckets=ring_seq_size // bucket_size,
         )
 
         self.layers = ModuleList([])
@@ -471,25 +473,28 @@ class RingTransformer(Module):
 
         for layer_max_lookback_seq_len in max_lookback_seq_len:
 
-            self.layers.append(ModuleList([
-                RingAttention(
-                    dim = dim,
-                    causal = causal,
-                    dim_head = dim_head,
-                    heads = heads,
-                    bucket_size = bucket_size,
-                    ring_attn = ring_attn,
-                    ring_seq_size = ring_seq_size,
-                    max_lookback_seq_len = layer_max_lookback_seq_len,
-                    striped_ring_attn = striped_ring_attn,
-                    auto_shard_seq = False,
-                ),
-                FeedForward(dim = dim, mult = ff_mult)
-            ]))
+            self.layers.append(
+                ModuleList(
+                    [
+                        RingAttention(
+                            dim=dim,
+                            causal=causal,
+                            dim_head=dim_head,
+                            heads=heads,
+                            bucket_size=bucket_size,
+                            ring_attn=ring_attn,
+                            ring_seq_size=ring_seq_size,
+                            max_lookback_seq_len=layer_max_lookback_seq_len,
+                            striped_ring_attn=striped_ring_attn,
+                            auto_shard_seq=False,
+                        ),
+                        FeedForward(dim=dim, mult=ff_mult),
+                    ]
+                )
+            )
 
         self.to_logits = nn.Sequential(
-            RMSNorm(dim),
-            nn.Linear(dim, num_tokens, bias = False)
+            RMSNorm(dim), nn.Linear(dim, num_tokens, bias=False)
         )
 
         # training related
@@ -499,15 +504,17 @@ class RingTransformer(Module):
     def forward(
         self,
         x,
-        mask = None,
-        labels = None,
-        return_loss = False,
-        force_ring_reduce_off = False,
-        ring_size = None
+        mask=None,
+        labels=None,
+        return_loss=False,
+        force_ring_reduce_off=False,
+        ring_size=None,
     ):
         seq_len, device = x.shape[-1], x.device
 
-        auto_shard_seq = not force_ring_reduce_off and self.auto_shard_seq and is_distributed()
+        auto_shard_seq = (
+            not force_ring_reduce_off and self.auto_shard_seq and is_distributed()
+        )
 
         # get labels if not passed in
 
@@ -528,27 +535,33 @@ class RingTransformer(Module):
             # labels
 
             if exists(labels):
-                labels, label_mask = maybe_pad_seq_and_mask(labels, mask[:, 1:], self.ring_seq_size)
+                labels, label_mask = maybe_pad_seq_and_mask(
+                    labels, mask[:, 1:], self.ring_seq_size
+                )
                 labels.masked_fill_(~label_mask, self.ignore_index)
 
             # account for striped attention
             # for workload balancing https://arxiv.org/abs/2311.09431 - MIT paper from Brandon et al.
 
             if self.striped_ring_attn:
-                x = rearrange('b (i j) -> b (j i)', x, i = self.bucket_size)
+                x = rearrange("b (i j) -> b (j i)", x, i=self.bucket_size)
 
                 if exists(labels):
-                    labels = rearrange('b (i j) -> b (j i)', labels, i = self.bucket_size)
+                    labels = rearrange("b (i j) -> b (j i)", labels, i=self.bucket_size)
 
                 if exists(mask):
-                    mask = rearrange('b (i j) -> b (j i)', mask, i = self.bucket_size)
+                    mask = rearrange("b (i j) -> b (j i)", mask, i=self.bucket_size)
 
             # gather across batch and divide across world
 
-            (x, mask), batch_sizes, num_sharded_batches = sharded_batch_to_sharded_seq(x, mask, self.ring_seq_size)
+            (x, mask), batch_sizes, num_sharded_batches = sharded_batch_to_sharded_seq(
+                x, mask, self.ring_seq_size
+            )
 
             if exists(labels):
-                (labels, _), *_ = sharded_batch_to_sharded_seq(labels, None, self.ring_seq_size)
+                (labels, _), *_ = sharded_batch_to_sharded_seq(
+                    labels, None, self.ring_seq_size
+                )
 
             # calculate ring size from num sharded batches
 
@@ -564,13 +577,16 @@ class RingTransformer(Module):
         x = self.token_emb(x)
 
         for attn, ff in self.layers:
-            x = attn(
-                x,
-                mask = mask,
-                rotary_emb = rotary_emb,
-                force_ring_reduce_off = force_ring_reduce_off,
-                ring_size = ring_size
-            ) + x
+            x = (
+                attn(
+                    x,
+                    mask=mask,
+                    rotary_emb=rotary_emb,
+                    force_ring_reduce_off=force_ring_reduce_off,
+                    ring_size=ring_size,
+                )
+                + x
+            )
 
             x = ff(x) + x
 
@@ -579,13 +595,9 @@ class RingTransformer(Module):
         # handle returning of loss
 
         if return_loss:
-            logits = rearrange('b n c -> b c n', logits)
+            logits = rearrange("b n c -> b c n", logits)
 
-            ce_loss = F.cross_entropy(
-                logits,
-                labels,
-                ignore_index = self.ignore_index
-            )
+            ce_loss = F.cross_entropy(logits, labels, ignore_index=self.ignore_index)
 
             return ce_loss
 
@@ -597,6 +609,6 @@ class RingTransformer(Module):
         logits = sharded_seq_to_sharded_batch(logits, batch_sizes, num_sharded_batches)
 
         if self.striped_ring_attn:
-            logits = rearrange('b (i j) d -> b (j i) d', logits, j = self.bucket_size)
+            logits = rearrange("b (i j) d -> b (j i) d", logits, j=self.bucket_size)
 
         return logits[:, :seq_len]

--- a/ring_attention_pytorch/ring_attention.py
+++ b/ring_attention_pytorch/ring_attention.py
@@ -15,34 +15,38 @@ from ring_attention_pytorch.ring import (
     all_ring_pass,
     is_distributed,
     get_rank,
-    get_world_size,
+    get_world_size
 )
 
-from ring_attention_pytorch.ring_flash_attention import ring_flash_attn
+from ring_attention_pytorch.ring_flash_attention import (
+    ring_flash_attn
+)
 
-from ring_attention_pytorch.distributed import split_by_rank, AllGather
+from ring_attention_pytorch.distributed import (
+    split_by_rank,
+    AllGather
+)
 
 # helper functions
-
 
 def exists(v):
     return v is not None
 
-
 def default(v, d):
     return v if exists(v) else d
 
-
-def cast_tuple(t, length=1):
+def cast_tuple(t, length = 1):
     return t if isinstance(t, tuple) else ((t,) * length)
-
 
 def divisible_by(num, den):
     return (num % den) == 0
 
-
 def default_attention(
-    q: Tensor, k: Tensor, v: Tensor, mask: Optional[Tensor] = None, causal: bool = False
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    mask: Optional[Tensor] = None,
+    causal: bool = False
 ):
     q = q * (q.shape[-1] ** -0.5)
 
@@ -50,31 +54,29 @@ def default_attention(
 
     # similarity
 
-    sim = einsum("b i h d, b j h d -> b h i j", q, k)
+    sim = einsum('b i h d, b j h d -> b h i j', q, k)
 
     # masking
 
     if causal:
         i, j = sim.shape[-2:]
-        causal_mask = torch.ones((i, j), dtype=torch.bool).triu(j - i + 1)
+        causal_mask = torch.ones((i, j), dtype = torch.bool).triu(j - i + 1)
         sim = torch.where(causal_mask, mask_value, sim)
 
     elif exists(mask):
-        sim = einx.where("b j, b h i j, -> b h i j", mask, sim, mask_value)
+        sim = einx.where('b j, b h i j, -> b h i j', mask, sim, mask_value)
 
     # attend
 
-    attn = einx.softmax("b h i [j]", sim)
+    attn = einx.softmax('b h i [j]', sim)
 
     # aggregate
 
-    out = einsum("b h i j, b j h d -> b i h d", attn, v)
+    out = einsum('b h i j, b j h d -> b i h d', attn, v)
 
     return out
 
-
 # rotary embeddings with modifications to support striped attention
-
 
 class RingRotaryEmbedding(Module):
     def __init__(
@@ -82,8 +84,8 @@ class RingRotaryEmbedding(Module):
         dim,
         ring: bool = False,
         striped: bool = False,
-        buckets: int = 1,  # in striped attention with flash buckets > 1, one needs to specify the number of buckets per machine
-        theta=10000,
+        buckets: int = 1,        # in striped attention with flash buckets > 1, one needs to specify the number of buckets per machine
+        theta = 10000
     ):
         super().__init__()
         self.ring = ring
@@ -91,14 +93,18 @@ class RingRotaryEmbedding(Module):
         self.buckets = buckets
 
         inv_freq = theta ** -(torch.arange(0, dim, 2).float() / dim)
-        self.register_buffer("inv_freq", inv_freq)
+        self.register_buffer('inv_freq', inv_freq)
 
     @property
     def device(self):
         return self.inv_freq.device
 
-    @autocast(enabled=False)
-    def forward(self, seq_len: int, offset=0):
+    @autocast(enabled = False)
+    def forward(
+        self,
+        seq_len: int,
+        offset = 0
+    ):
         device = self.device
         pos = None
 
@@ -108,39 +114,39 @@ class RingRotaryEmbedding(Module):
                 ring_stride = get_world_size() * buckets
                 ring_offset = buckets
 
-                pos = torch.arange(seq_len // buckets, device=device)
-                pos = rearrange("n -> n b", pos, b=buckets)
+                pos = torch.arange(seq_len // buckets, device = device)
+                pos = rearrange('n -> n b', pos, b = buckets)
 
                 pos = pos * ring_stride
-                pos += torch.arange(buckets, device=device) + (get_rank() * buckets)
-                pos = rearrange("n b -> (b n)", pos)
+                pos += torch.arange(buckets, device = device) + (get_rank() * buckets)
+                pos = rearrange('n b -> (b n)', pos)
 
             else:
-                pos = torch.arange(seq_len, device=device)
+                pos = torch.arange(seq_len, device = device)
                 pos += seq_len * get_rank()
         else:
-            pos = torch.arange(seq_len, device=device)
+            pos = torch.arange(seq_len, device = device)
 
         pos = pos.type_as(self.inv_freq)
-        freqs = torch.einsum("i , j -> i j", pos, self.inv_freq)
-        return torch.cat((freqs, freqs), dim=-1)
-
+        freqs = torch.einsum('i , j -> i j', pos, self.inv_freq)
+        return torch.cat((freqs, freqs), dim = -1)
 
 def rotate_half(x):
-    x1, x2 = x.chunk(2, dim=-1)
+    x1, x2 = x.chunk(2, dim = -1)
     return torch.cat((-x2, x1), dim=-1)
 
-
-@autocast(enabled=False)
+@autocast(enabled = False)
 def apply_rotary_pos_emb(pos, t):
-    pos = rearrange("n d -> n 1 d", pos)
+    pos = rearrange('n d -> n 1 d', pos)
     return t * pos.cos() + rotate_half(t) * pos.sin()
-
 
 # batch to sequence sharding and back
 
-
-def pad_to_multiple(x: Tensor, length: int, pad_value=0):
+def pad_to_multiple(
+    x: Tensor,
+    length: int,
+    pad_value = 0
+):
     seq_len = x.shape[-1]
     remainder = seq_len % length
 
@@ -148,10 +154,13 @@ def pad_to_multiple(x: Tensor, length: int, pad_value=0):
         return x, 0
 
     pad_length = length - remainder
-    return F.pad(x, (0, pad_length), value=pad_value), pad_length
+    return F.pad(x, (0, pad_length), value = pad_value), pad_length
 
-
-def maybe_pad_seq_and_mask(x: Tensor, mask: Optional[Tensor], seq_size: int):
+def maybe_pad_seq_and_mask(
+    x: Tensor,
+    mask: Optional[Tensor],
+    seq_size: int
+):
     orig_x, seq_len = x, x.shape[-1]
 
     # auto pad sequence and mask, as ring passing makes assumption tensor is all same shape
@@ -164,17 +173,20 @@ def maybe_pad_seq_and_mask(x: Tensor, mask: Optional[Tensor], seq_size: int):
     if not exists(mask):
         mask = torch.ones_like(orig_x).bool()
 
-    mask, _ = pad_to_multiple(mask, seq_size, pad_value=False)
+    mask, _ = pad_to_multiple(mask, seq_size, pad_value = False)
 
     return x, mask
 
-
-def sharded_batch_to_sharded_seq(x: Tensor, mask: Optional[Tensor], seq_size: int):
+def sharded_batch_to_sharded_seq(
+    x: Tensor,
+    mask: Optional[Tensor],
+    seq_size: int
+):
     assert is_distributed()
 
     # all gather across batch
 
-    all_gather = AllGather(dim=0)
+    all_gather = AllGather(dim = 0)
 
     x, sizes = all_gather(x)
 
@@ -191,38 +203,39 @@ def sharded_batch_to_sharded_seq(x: Tensor, mask: Optional[Tensor], seq_size: in
 
     num_sharded_batches = world_size // total_split_seq
 
-    x = rearrange("(b s) n -> b (s n)", x, s=num_sharded_batches)
+    x = rearrange('(b s) n -> b (s n)', x, s = num_sharded_batches)
 
     # then split sequence across machines
 
-    x = x.split(seq_size, dim=-1)
+    x = x.split(seq_size, dim = -1)
 
     x, _ = split_by_rank(x)
 
     if exists(mask):
-        mask = rearrange("(b s) n -> b (s n)", mask, s=num_sharded_batches)
-        mask = mask.split(seq_size, dim=-1)
+        mask = rearrange('(b s) n -> b (s n)', mask, s = num_sharded_batches)
+        mask = mask.split(seq_size, dim = -1)
         mask, _ = split_by_rank(mask)
 
     return (x, mask), sizes, num_sharded_batches
 
-
-def sharded_seq_to_sharded_batch(logits: Tensor, sizes, num_sharded_batches=1):
-    all_gather = AllGather(dim=-2)  # all gather across sequence
+def sharded_seq_to_sharded_batch(
+    logits: Tensor,
+    sizes,
+    num_sharded_batches = 1
+):
+    all_gather = AllGather(dim = -2) # all gather across sequence
 
     logits, _ = all_gather(logits)
 
-    logits = rearrange("b (s n) c -> (b s) n c", logits, s=num_sharded_batches)
+    logits = rearrange('b (s n) c -> (b s) n c', logits, s = num_sharded_batches)
 
-    logits = logits.split(sizes.tolist(), dim=0)
+    logits = logits.split(sizes.tolist(), dim = 0)
 
     logits, _ = split_by_rank(logits)
 
     return logits
 
-
 # main class
-
 
 class RingAttention(Module):
     @beartype
@@ -249,7 +262,7 @@ class RingAttention(Module):
         super().__init__()
         self.eps = eps
         self.heads = heads
-        self.scale = dim_head**-0.5
+        self.scale = dim_head ** -0.5
         self.causal = causal
 
         assert divisible_by(ring_seq_size, bucket_size)
@@ -259,9 +272,7 @@ class RingAttention(Module):
         self.striped_ring_attn = striped_ring_attn
 
         self.force_regular_attn = force_regular_attn
-        self.auto_shard_seq = default(
-            auto_shard_seq, ring_attn
-        )  # this should be done at the transformer level on the token ids for efficiency, but for testing purposes
+        self.auto_shard_seq = default(auto_shard_seq, ring_attn) # this should be done at the transformer level on the token ids for efficiency, but for testing purposes
 
         assert not (not self.ring_attn and self.auto_shard_seq)
 
@@ -273,11 +284,11 @@ class RingAttention(Module):
         self.rotary_embed = None
         if rotary_embed:
             self.rotary_embed = RingRotaryEmbedding(
-                dim=dim_head,
-                ring=ring_attn,
-                striped=striped_ring_attn,
-                theta=rotary_embed_theta,
-                buckets=ring_seq_size // bucket_size,
+                dim = dim_head,
+                ring = ring_attn,
+                striped = striped_ring_attn,
+                theta = rotary_embed_theta,
+                buckets = ring_seq_size // bucket_size
             )
 
         # projections
@@ -286,10 +297,10 @@ class RingAttention(Module):
 
         self.to_qkv = nn.Sequential(
             RMSNorm(dim) if prenorm else nn.Identity(),
-            nn.Linear(dim, dim_inner * 3, bias=False),
+            nn.Linear(dim, dim_inner * 3, bias = False)
         )
 
-        self.to_out = nn.Linear(dim_inner, dim, bias=False)
+        self.to_out = nn.Linear(dim_inner, dim, bias = False)
 
         # whether to use flash attention cuda kernel
 
@@ -299,10 +310,10 @@ class RingAttention(Module):
     def forward(
         self,
         x,
-        mask=None,
-        rotary_emb=None,
-        force_ring_reduce_off=False,
-        ring_size=None,
+        mask = None,
+        rotary_emb = None,
+        force_ring_reduce_off = False,
+        ring_size = None,
     ):
         """
         einstein notation
@@ -323,19 +334,17 @@ class RingAttention(Module):
             x, mask = maybe_pad_seq_and_mask(x, mask, self.ring_seq_size)
 
             if self.striped_ring_attn:
-                x = rearrange("b (i j) d -> b (j i) d", x, i=self.bucket_size)
+                x = rearrange('b (i j) d -> b (j i) d', x, i = self.bucket_size)
 
                 if exists(mask):
-                    mask = rearrange("b (i j) -> b (j i)", mask, i=self.bucket_size)
+                    mask = rearrange('b (i j) -> b (j i)', mask, i = self.bucket_size)
 
-            (x, mask), batch_sizes = sharded_batch_to_sharded_seq(
-                x, mask, self.ring_seq_size
-            )
+            (x, mask), batch_sizes = sharded_batch_to_sharded_seq(x, mask, self.ring_seq_size)
 
         device = x.device
 
         qkv = self.to_qkv(x)
-        q, k, v = rearrange("b n (qkv h d) -> qkv b n h d", qkv, qkv=3, h=self.heads)
+        q, k, v = rearrange('b n (qkv h d) -> qkv b n h d', qkv, qkv = 3, h = self.heads)
 
         # rotary relative positions
 
@@ -351,43 +360,37 @@ class RingAttention(Module):
         any_cuda_inputs = any([t.is_cuda for t in (q, k, v)])
 
         if self.force_regular_attn:
-            out = default_attention(q, k, v, mask=mask, causal=self.causal)
+            out = default_attention(q, k, v, mask = mask, causal = self.causal)
 
         elif any_cuda_inputs and self.use_cuda_kernel:
-            from ring_attention_pytorch.ring_flash_attention_cuda import (
-                ring_flash_attn_cuda,
-            )
+            from ring_attention_pytorch.ring_flash_attention_cuda import ring_flash_attn_cuda
 
             out = ring_flash_attn_cuda(
-                q,
-                k,
-                v,
+                q, k, v,
                 mask,
                 self.causal,
                 self.bucket_size,
                 ring_attn and not force_ring_reduce_off,
                 self.striped_ring_attn and not force_ring_reduce_off,
                 self.max_lookback_seq_len,
-                ring_size,
+                ring_size
             )
 
         else:
             out = ring_flash_attn(
-                q,
-                k,
-                v,
+                q, k, v,
                 mask,
                 self.causal,
                 self.bucket_size,
                 ring_attn and not force_ring_reduce_off,
                 self.striped_ring_attn and not force_ring_reduce_off,
                 self.max_lookback_seq_len,
-                ring_size,
+                ring_size
             )
 
         # combine heads
 
-        out = rearrange("b n h d -> b n (h d)", out)
+        out = rearrange('b n h d -> b n (h d)', out)
         out = self.to_out(out)
 
         if auto_shard_seq:
@@ -396,26 +399,25 @@ class RingAttention(Module):
 
         return out
 
-
 # simple transformer for end2end testing
-
 
 class RMSNorm(Module):
     def __init__(self, dim):
         super().__init__()
-        self.scale = dim**0.5
+        self.scale = dim ** 0.5
         self.gamma = nn.Parameter(torch.ones(dim))
 
     def forward(self, x):
-        return F.normalize(x, dim=-1) * self.scale * self.gamma
+        return F.normalize(x, dim = -1) * self.scale * self.gamma
 
-
-def FeedForward(dim, mult=4):
+def FeedForward(dim, mult = 4):
     dim_inner = int(dim * mult)
     return nn.Sequential(
-        RMSNorm(dim), nn.Linear(dim, dim_inner), nn.GELU(), nn.Linear(dim_inner, dim)
+        RMSNorm(dim),
+        nn.Linear(dim, dim_inner),
+        nn.GELU(),
+        nn.Linear(dim_inner, dim)
     )
-
 
 class RingTransformer(Module):
     @beartype
@@ -435,7 +437,7 @@ class RingTransformer(Module):
         ring_seq_size: int = 512,
         auto_shard_seq: Optional[bool] = None,
         max_lookback_seq_len: Optional[Union[Tuple[int, ...], int]] = None,
-        rotary_embed_theta: int = 10000,  # will need to be changed for the million token context
+        rotary_embed_theta: int = 10000,    # will need to be changed for the million token context
         ignore_index: int = -1
     ):
         super().__init__()
@@ -446,24 +448,20 @@ class RingTransformer(Module):
         self.bucket_size = bucket_size
         assert divisible_by(ring_seq_size, bucket_size)
 
-        self.auto_shard_seq = default(
-            auto_shard_seq, ring_attn
-        )  # if ring attention is turned on, auto-shard across sequence dimension. this can also be turned off and done manually elsewhere in the data loading
+        self.auto_shard_seq = default(auto_shard_seq, ring_attn) # if ring attention is turned on, auto-shard across sequence dimension. this can also be turned off and done manually elsewhere in the data loading
 
         assert not (not self.ring_attn and self.auto_shard_seq)
         assert not (not self.ring_attn and self.striped_ring_attn)
-        assert not (
-            self.striped_ring_attn and not causal
-        ), "striped ring attention only applies to autoregressive models"
+        assert not (self.striped_ring_attn and not causal), 'striped ring attention only applies to autoregressive models'
 
         self.token_emb = nn.Embedding(num_tokens, dim)
 
         self.rotary_emb = RingRotaryEmbedding(
-            dim=dim_head,
-            ring=ring_attn,
-            striped=striped_ring_attn,
-            theta=rotary_embed_theta,
-            buckets=ring_seq_size // bucket_size,
+            dim = dim_head,
+            ring = ring_attn,
+            striped = striped_ring_attn,
+            theta = rotary_embed_theta,
+            buckets = ring_seq_size // bucket_size
         )
 
         self.layers = ModuleList([])
@@ -473,28 +471,25 @@ class RingTransformer(Module):
 
         for layer_max_lookback_seq_len in max_lookback_seq_len:
 
-            self.layers.append(
-                ModuleList(
-                    [
-                        RingAttention(
-                            dim=dim,
-                            causal=causal,
-                            dim_head=dim_head,
-                            heads=heads,
-                            bucket_size=bucket_size,
-                            ring_attn=ring_attn,
-                            ring_seq_size=ring_seq_size,
-                            max_lookback_seq_len=layer_max_lookback_seq_len,
-                            striped_ring_attn=striped_ring_attn,
-                            auto_shard_seq=False,
-                        ),
-                        FeedForward(dim=dim, mult=ff_mult),
-                    ]
-                )
-            )
+            self.layers.append(ModuleList([
+                RingAttention(
+                    dim = dim,
+                    causal = causal,
+                    dim_head = dim_head,
+                    heads = heads,
+                    bucket_size = bucket_size,
+                    ring_attn = ring_attn,
+                    ring_seq_size = ring_seq_size,
+                    max_lookback_seq_len = layer_max_lookback_seq_len,
+                    striped_ring_attn = striped_ring_attn,
+                    auto_shard_seq = False,
+                ),
+                FeedForward(dim = dim, mult = ff_mult)
+            ]))
 
         self.to_logits = nn.Sequential(
-            RMSNorm(dim), nn.Linear(dim, num_tokens, bias=False)
+            RMSNorm(dim),
+            nn.Linear(dim, num_tokens, bias = False)
         )
 
         # training related
@@ -504,17 +499,15 @@ class RingTransformer(Module):
     def forward(
         self,
         x,
-        mask=None,
-        labels=None,
-        return_loss=False,
-        force_ring_reduce_off=False,
-        ring_size=None,
+        mask = None,
+        labels = None,
+        return_loss = False,
+        force_ring_reduce_off = False,
+        ring_size = None
     ):
         seq_len, device = x.shape[-1], x.device
 
-        auto_shard_seq = (
-            not force_ring_reduce_off and self.auto_shard_seq and is_distributed()
-        )
+        auto_shard_seq = not force_ring_reduce_off and self.auto_shard_seq and is_distributed()
 
         # get labels if not passed in
 
@@ -535,33 +528,27 @@ class RingTransformer(Module):
             # labels
 
             if exists(labels):
-                labels, label_mask = maybe_pad_seq_and_mask(
-                    labels, mask[:, 1:], self.ring_seq_size
-                )
+                labels, label_mask = maybe_pad_seq_and_mask(labels, mask[:, 1:], self.ring_seq_size)
                 labels.masked_fill_(~label_mask, self.ignore_index)
 
             # account for striped attention
             # for workload balancing https://arxiv.org/abs/2311.09431 - MIT paper from Brandon et al.
 
             if self.striped_ring_attn:
-                x = rearrange("b (i j) -> b (j i)", x, i=self.bucket_size)
+                x = rearrange('b (i j) -> b (j i)', x, i = self.bucket_size)
 
                 if exists(labels):
-                    labels = rearrange("b (i j) -> b (j i)", labels, i=self.bucket_size)
+                    labels = rearrange('b (i j) -> b (j i)', labels, i = self.bucket_size)
 
                 if exists(mask):
-                    mask = rearrange("b (i j) -> b (j i)", mask, i=self.bucket_size)
+                    mask = rearrange('b (i j) -> b (j i)', mask, i = self.bucket_size)
 
             # gather across batch and divide across world
 
-            (x, mask), batch_sizes, num_sharded_batches = sharded_batch_to_sharded_seq(
-                x, mask, self.ring_seq_size
-            )
+            (x, mask), batch_sizes, num_sharded_batches = sharded_batch_to_sharded_seq(x, mask, self.ring_seq_size)
 
             if exists(labels):
-                (labels, _), *_ = sharded_batch_to_sharded_seq(
-                    labels, None, self.ring_seq_size
-                )
+                (labels, _), *_ = sharded_batch_to_sharded_seq(labels, None, self.ring_seq_size)
 
             # calculate ring size from num sharded batches
 
@@ -577,16 +564,13 @@ class RingTransformer(Module):
         x = self.token_emb(x)
 
         for attn, ff in self.layers:
-            x = (
-                attn(
-                    x,
-                    mask=mask,
-                    rotary_emb=rotary_emb,
-                    force_ring_reduce_off=force_ring_reduce_off,
-                    ring_size=ring_size,
-                )
-                + x
-            )
+            x = attn(
+                x,
+                mask = mask,
+                rotary_emb = rotary_emb,
+                force_ring_reduce_off = force_ring_reduce_off,
+                ring_size = ring_size
+            ) + x
 
             x = ff(x) + x
 
@@ -595,9 +579,13 @@ class RingTransformer(Module):
         # handle returning of loss
 
         if return_loss:
-            logits = rearrange("b n c -> b c n", logits)
+            logits = rearrange('b n c -> b c n', logits)
 
-            ce_loss = F.cross_entropy(logits, labels, ignore_index=self.ignore_index)
+            ce_loss = F.cross_entropy(
+                logits,
+                labels,
+                ignore_index = self.ignore_index
+            )
 
             return ce_loss
 
@@ -609,6 +597,6 @@ class RingTransformer(Module):
         logits = sharded_seq_to_sharded_batch(logits, batch_sizes, num_sharded_batches)
 
         if self.striped_ring_attn:
-            logits = rearrange("b (i j) d -> b (j i) d", logits, j=self.bucket_size)
+            logits = rearrange('b (i j) d -> b (j i) d', logits, j = self.bucket_size)
 
         return logits[:, :seq_len]

--- a/ring_attention_pytorch/ring_flash_attention_cuda.py
+++ b/ring_attention_pytorch/ring_flash_attention_cuda.py
@@ -7,6 +7,7 @@ import torch
 from torch import nn, einsum, Tensor
 import torch.nn.functional as F
 from torch.autograd.function import Function
+from einops import repeat
 
 from ring_attention_pytorch.ring import (
     ring_pass,
@@ -14,7 +15,7 @@ from ring_attention_pytorch.ring import (
     null_ring_pass,
     one_ring_pass,
     get_rank,
-    get_world_size
+    get_world_size,
 )
 
 from beartype import beartype
@@ -23,38 +24,46 @@ from einops import repeat
 
 # helpers
 
+
 def exists(v):
     return v is not None
 
-def pad_at_dim(t, pad: Tuple[int, int], *, dim = -1, value = 0.):
-    dims_from_right = (- dim - 1) if dim < 0 else (t.ndim - dim - 1)
-    zeros = ((0, 0) * dims_from_right)
-    return F.pad(t, (*zeros, *pad), value = value)
+
+def pad_at_dim(t, pad: Tuple[int, int], *, dim=-1, value=0.0):
+    dims_from_right = (-dim - 1) if dim < 0 else (t.ndim - dim - 1)
+    zeros = (0, 0) * dims_from_right
+    return F.pad(t, (*zeros, *pad), value=value)
+
 
 def is_contiguous(x):
     return x.stride(-1) == 1
+
 
 # make sure flash attention is installed for backwards
 
 import importlib
 from importlib.metadata import version
 
-assert exists(importlib.util.find_spec('flash_attn')), 'flash-attn must be installed. `pip install flash-attn --no-build-isolation` first'
+assert exists(
+    importlib.util.find_spec("flash_attn")
+), "flash-attn must be installed. `pip install flash-attn --no-build-isolation` first"
 
-flash_attn_version = version('flash_attn')
-assert pkg_version.parse(flash_attn_version) >= pkg_version.parse('2.5.1')
+flash_attn_version = version("flash_attn")
+assert pkg_version.parse(flash_attn_version) >= pkg_version.parse("2.5.1")
 
 from flash_attn.flash_attn_interface import (
     _flash_attn_varlen_backward,
-    _flash_attn_backward
+    _flash_attn_backward,
 )
 
 # make sure triton is installed for forwards
 
-assert exists(importlib.util.find_spec('triton')), 'latest triton must be installed. `pip install triton -U` first'
+assert exists(
+    importlib.util.find_spec("triton")
+), "latest triton must be installed. `pip install triton -U` first"
 
-triton_version = version('triton')
-assert pkg_version.parse(triton_version) >= pkg_version.parse('2.1')
+triton_version = version("triton")
+assert pkg_version.parse(triton_version) >= pkg_version.parse("2.1")
 
 import triton
 import triton.language as tl
@@ -62,6 +71,7 @@ import triton.language as tl
 # taking the flash attention forwards from Tri's flash_attn repository
 # https://github.com/Dao-AILab/flash-attention/blob/main/flash_attn/flash_attn_triton.py
 # and modifying to return unnormalized accumulation, row maxes, row lse - reduced over passed rings
+
 
 @triton.heuristics(
     {
@@ -124,13 +134,22 @@ def _fwd_kernel(
     offs_d = tl.arange(0, BLOCK_HEADDIM)
 
     q_ptrs = (
-        Q + off_b * stride_qb + off_h * stride_qh + (offs_m[:, None] * stride_qm + offs_d[None, :])
+        Q
+        + off_b * stride_qb
+        + off_h * stride_qh
+        + (offs_m[:, None] * stride_qm + offs_d[None, :])
     )
     k_ptrs = (
-        K + off_b * stride_kb + off_h * stride_kh + (offs_n[:, None] * stride_kn + offs_d[None, :])
+        K
+        + off_b * stride_kb
+        + off_h * stride_kh
+        + (offs_n[:, None] * stride_kn + offs_d[None, :])
     )
     v_ptrs = (
-        V + off_b * stride_vb + off_h * stride_vh + (offs_n[:, None] * stride_vn + offs_d[None, :])
+        V
+        + off_b * stride_vb
+        + off_h * stride_vh
+        + (offs_n[:, None] * stride_vn + offs_d[None, :])
     )
 
     if HAS_BIAS:
@@ -176,7 +195,8 @@ def _fwd_kernel(
                 acc_o = tl.load(out_ptrs, mask=offs_m[:, None] < seqlen_q)
             else:
                 acc_o = tl.load(
-                    out_ptrs, mask=(offs_m[:, None] < seqlen_q) & (offs_d[None, :] < headdim)
+                    out_ptrs,
+                    mask=(offs_m[:, None] < seqlen_q) & (offs_d[None, :] < headdim),
                 )
 
         acc_o = acc_o.to(tl.float32)
@@ -195,7 +215,9 @@ def _fwd_kernel(
             q = tl.load(q_ptrs, mask=offs_m[:, None] < seqlen_q, other=0.0)
         else:
             q = tl.load(
-                q_ptrs, mask=(offs_m[:, None] < seqlen_q) & (offs_d[None, :] < headdim), other=0.0
+                q_ptrs,
+                mask=(offs_m[:, None] < seqlen_q) & (offs_d[None, :] < headdim),
+                other=0.0,
             )
 
     end_n = seqlen_k if not IS_CAUSAL else tl.minimum((start_m + 1) * BLOCK_M, seqlen_k)
@@ -206,7 +228,11 @@ def _fwd_kernel(
             if EVEN_HEADDIM:
                 k = tl.load(k_ptrs + start_n * stride_kn)
             else:
-                k = tl.load(k_ptrs + start_n * stride_kn, mask=offs_d[None, :] < headdim, other=0.0)
+                k = tl.load(
+                    k_ptrs + start_n * stride_kn,
+                    mask=offs_d[None, :] < headdim,
+                    other=0.0,
+                )
         else:
             if EVEN_HEADDIM:
                 k = tl.load(
@@ -217,7 +243,8 @@ def _fwd_kernel(
             else:
                 k = tl.load(
                     k_ptrs + start_n * stride_kn,
-                    mask=((start_n + offs_n)[:, None] < seqlen_k) & (offs_d[None, :] < headdim),
+                    mask=((start_n + offs_n)[:, None] < seqlen_k)
+                    & (offs_d[None, :] < headdim),
                     other=0.0,
                 )
         qk = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
@@ -229,9 +256,13 @@ def _fwd_kernel(
         if IS_CAUSAL:
             if CAUSAL_MASK_DIAGONAL:
                 # needed for stripe attention
-                qk += tl.where(offs_m[:, None] > (start_n + offs_n)[None, :], 0, float("-inf"))
+                qk += tl.where(
+                    offs_m[:, None] > (start_n + offs_n)[None, :], 0, float("-inf")
+                )
             else:
-                qk += tl.where(offs_m[:, None] >= (start_n + offs_n)[None, :], 0, float("-inf"))
+                qk += tl.where(
+                    offs_m[:, None] >= (start_n + offs_n)[None, :], 0, float("-inf")
+                )
 
         if HAS_BIAS:
             if EVEN_N:
@@ -259,7 +290,11 @@ def _fwd_kernel(
             if EVEN_HEADDIM:
                 v = tl.load(v_ptrs + start_n * stride_vn)
             else:
-                v = tl.load(v_ptrs + start_n * stride_vn, mask=offs_d[None, :] < headdim, other=0.0)
+                v = tl.load(
+                    v_ptrs + start_n * stride_vn,
+                    mask=offs_d[None, :] < headdim,
+                    other=0.0,
+                )
         else:
             if EVEN_HEADDIM:
                 v = tl.load(
@@ -270,7 +305,8 @@ def _fwd_kernel(
             else:
                 v = tl.load(
                     v_ptrs + start_n * stride_vn,
-                    mask=((start_n + offs_n)[:, None] < seqlen_k) & (offs_d[None, :] < headdim),
+                    mask=((start_n + offs_n)[:, None] < seqlen_k)
+                    & (offs_d[None, :] < headdim),
                     other=0.0,
                 )
 
@@ -311,22 +347,25 @@ def _fwd_kernel(
             tl.store(out_ptrs, acc_o, mask=offs_m[:, None] < seqlen_q)
         else:
             tl.store(
-                out_ptrs, acc_o, mask=(offs_m[:, None] < seqlen_q) & (offs_d[None, :] < headdim)
+                out_ptrs,
+                acc_o,
+                mask=(offs_m[:, None] < seqlen_q) & (offs_d[None, :] < headdim),
             )
+
 
 def flash_attn_forward(
     q,
     k,
     v,
-    bias = None,
-    causal = False,
-    o = None,
-    m = None,
-    lse = None,
-    softmax_scale = None,
-    causal_mask_diagonal = False,
-    return_normalized_output = False,
-    load_accumulated = True
+    bias=None,
+    causal=False,
+    o=None,
+    m=None,
+    lse=None,
+    softmax_scale=None,
+    causal_mask_diagonal=False,
+    return_normalized_output=False,
+    load_accumulated=True,
 ):
     q, k, v = [x if is_contiguous(x) else x.contiguous() for x in (q, k, v)]
 
@@ -340,7 +379,7 @@ def flash_attn_forward(
     assert q.dtype in [torch.float16, torch.bfloat16], "Only support fp16 and bf16"
     assert q.is_cuda and k.is_cuda and v.is_cuda
 
-    softmax_scale = default(softmax_scale, d ** -0.5)
+    softmax_scale = default(softmax_scale, d**-0.5)
 
     has_bias = exists(bias)
 
@@ -349,7 +388,7 @@ def flash_attn_forward(
         assert bias.is_cuda
 
         if bias.ndim == 2:
-            bias = repeat(bias, 'b j -> b h i j', h = nheads, i = seqlen_q)
+            bias = repeat(bias, "b j -> b h i j", h=nheads, i=seqlen_q)
 
         if not is_contiguous(bias):
             bias = bias.contiguous()
@@ -357,19 +396,33 @@ def flash_attn_forward(
         assert bias.shape[-2:] == (1, seqlen_k)
         bias = bias.expand(batch, nheads, seqlen_q, seqlen_k)
 
-    bias_strides = (bias.stride(0), bias.stride(1), bias.stride(2)) if has_bias else (0, 0, 0)
+    bias_strides = (
+        (bias.stride(0), bias.stride(1), bias.stride(2)) if has_bias else (0, 0, 0)
+    )
 
     seqlen_q_rounded = math.ceil(seqlen_q / 128) * 128
 
     if not exists(lse):
         max_neg_value = -torch.finfo(torch.float32).max
-        init_fn = partial(torch.full, fill_value = max_neg_value) if load_accumulated else torch.empty
-        lse = init_fn((batch, nheads, seqlen_q_rounded), device=q.device, dtype=torch.float32)
+        init_fn = (
+            partial(torch.full, fill_value=max_neg_value)
+            if load_accumulated
+            else torch.empty
+        )
+        lse = init_fn(
+            (batch, nheads, seqlen_q_rounded), device=q.device, dtype=torch.float32
+        )
 
     if not exists(m):
         max_neg_value = -torch.finfo(torch.float32).max
-        init_fn = partial(torch.full, fill_value = max_neg_value) if load_accumulated else torch.empty
-        m = init_fn((batch, nheads, seqlen_q_rounded), device=q.device, dtype=torch.float32)
+        init_fn = (
+            partial(torch.full, fill_value=max_neg_value)
+            if load_accumulated
+            else torch.empty
+        )
+        m = init_fn(
+            (batch, nheads, seqlen_q_rounded), device=q.device, dtype=torch.float32
+        )
 
     if not exists(o):
         init_fn = torch.zeros_like if load_accumulated else torch.empty_like
@@ -415,30 +468,36 @@ def flash_attn_forward(
         load_accumulated,
         return_normalized_output,
         BLOCK_HEADDIM,
-        BLOCK_M = BLOCK,
-        BLOCK_N = BLOCK,
-        num_warps = num_warps,
-        num_stages = 1,
+        BLOCK_M=BLOCK,
+        BLOCK_N=BLOCK,
+        num_warps=num_warps,
+        num_stages=1,
     )
 
     return o, m, lse
 
+
 # helper functions
+
 
 def exists(val):
     return val is not None
 
+
 def default(val, d):
     return val if exists(val) else d
 
+
 def divisible_by(num, den):
     return (num % den) == 0
+
 
 # ring + (flash) attention forwards and backwards
 
 # flash attention v1 - https://arxiv.org/abs/2205.14135
 # flash attention v2 - https://tridao.me/publications/flash2/flash2.pdf
 # ring attention - https://arxiv.org/abs/2310.01889
+
 
 class RingFlashAttentionCUDAFunction(Function):
 
@@ -455,9 +514,9 @@ class RingFlashAttentionCUDAFunction(Function):
         ring_reduce_col: bool,
         striped_ring_attn: bool,
         max_lookback_seq_len: Optional[int],
-        ring_size: Optional[int]
+        ring_size: Optional[int],
     ):
-        assert all([t.is_cuda for t in (q, k, v)]), 'inputs must be all on cuda'
+        assert all([t.is_cuda for t in (q, k, v)]), "inputs must be all on cuda"
 
         dtype = q.dtype
         softmax_scale = q.shape[-1] ** -0.5
@@ -478,18 +537,22 @@ class RingFlashAttentionCUDAFunction(Function):
         ring_reduce_col &= not cross_attn
         striped_ring_attn &= not cross_attn
 
-        assert k.shape[-1] == v.shape[-1], 'for simplicity when doing ring passing, assume dim_values is equal to dim_queries_keys, majority of transformer do this, not a big issue'
+        assert (
+            k.shape[-1] == v.shape[-1]
+        ), "for simplicity when doing ring passing, assume dim_values is equal to dim_queries_keys, majority of transformer do this, not a big issue"
 
         per_machine_seq_size = k.shape[-3]
 
         # calculate max ring passes
 
         max_ring_passes = None
-        num_lookback_buckets = float('inf')
+        num_lookback_buckets = float("inf")
 
         if exists(max_lookback_seq_len):
             assert causal
-            assert not (ring_reduce_col and not divisible_by(per_machine_seq_size, bucket_size))
+            assert not (
+                ring_reduce_col and not divisible_by(per_machine_seq_size, bucket_size)
+            )
 
             max_ring_passes = math.ceil(max_lookback_seq_len / per_machine_seq_size)
             num_lookback_buckets = max_lookback_seq_len // bucket_size
@@ -525,7 +588,16 @@ class RingFlashAttentionCUDAFunction(Function):
         receive_kv = None
         receive_mask = None
 
-        for (ring_rank, is_last), ((kv, mask), (receive_kv, receive_mask)) in ring_pass_fn(kv, mask, receive_buffers = (receive_kv, receive_mask), max_iters = max_ring_passes, ring_size = ring_size):
+        for (ring_rank, is_last), (
+            (kv, mask),
+            (receive_kv, receive_mask),
+        ) in ring_pass_fn(
+            kv,
+            mask,
+            receive_buffers=(receive_kv, receive_mask),
+            max_iters=max_ring_passes,
+            ring_size=ring_size,
+        ):
             is_first = ring_rank == get_rank()
 
             k, v = kv
@@ -535,7 +607,7 @@ class RingFlashAttentionCUDAFunction(Function):
             bias = None
 
             if exists(mask):
-                bias = torch.where(mask, 0.,  max_neg_value)
+                bias = torch.where(mask, 0.0, max_neg_value)
 
             # for non-striped attention
             # if the kv ring rank is equal to the current rank (block diagonal), then turn on causal
@@ -555,16 +627,18 @@ class RingFlashAttentionCUDAFunction(Function):
                         continue
 
             o, m, lse = flash_attn_forward(
-                q, k, v,
-                causal = block_causal,
-                o = o,
-                m = m,
-                lse = lse,
-                bias = bias,
-                softmax_scale = softmax_scale,
-                causal_mask_diagonal = causal_mask_diagonal,
-                return_normalized_output = is_last,
-                load_accumulated = not is_first
+                q,
+                k,
+                v,
+                causal=block_causal,
+                o=o,
+                m=m,
+                lse=lse,
+                bias=bias,
+                softmax_scale=softmax_scale,
+                causal_mask_diagonal=causal_mask_diagonal,
+                return_normalized_output=is_last,
+                load_accumulated=not is_first,
             )
 
         ctx.args = (
@@ -577,7 +651,7 @@ class RingFlashAttentionCUDAFunction(Function):
             num_lookback_buckets,
             striped_ring_attn,
             ring_size,
-            dtype
+            dtype,
         )
 
         ctx.save_for_backward(q, orig_k, orig_v, o, lse)
@@ -590,7 +664,7 @@ class RingFlashAttentionCUDAFunction(Function):
     @staticmethod
     @torch.no_grad()
     def backward(ctx, do):
-        """ Algorithm 2 in the v2 paper """
+        """Algorithm 2 in the v2 paper"""
 
         (
             causal,
@@ -602,7 +676,7 @@ class RingFlashAttentionCUDAFunction(Function):
             num_lookback_buckets,
             striped_ring_attn,
             ring_size,
-            dtype
+            dtype,
         ) = ctx.args
 
         q, k, v, o, lse = ctx.saved_tensors
@@ -623,9 +697,9 @@ class RingFlashAttentionCUDAFunction(Function):
 
         device = q.device
 
-        dq = torch.zeros(q.shape, device = device, dtype = torch.float32)
-        dk = torch.zeros(k.shape, device = device, dtype = torch.float32)
-        dv = torch.zeros(v.shape, device = device, dtype = torch.float32)
+        dq = torch.zeros(q.shape, device=device, dtype=torch.float32)
+        dk = torch.zeros(k.shape, device=device, dtype=torch.float32)
+        dv = torch.zeros(v.shape, device=device, dtype=torch.float32)
 
         # k and v will have 16 bits, while dk, dv needs to be kept at 32
         # view everything as int for ring passing
@@ -634,7 +708,7 @@ class RingFlashAttentionCUDAFunction(Function):
         k_dtype, v_dtype = k.dtype, v.dtype
 
         k, v = map(lambda t: t.view(torch.float32), (k, v))
-        kv = torch.cat((k, v), dim = -1)
+        kv = torch.cat((k, v), dim=-1)
 
         kv_and_dkv = torch.stack((kv, dk, dv))
 
@@ -643,13 +717,22 @@ class RingFlashAttentionCUDAFunction(Function):
         receive_kv_and_dkv = None
         receive_mask = None
 
-        for (ring_rank, is_last), ((kv_and_dkv, mask), (receive_kv_and_dkv, receive_mask)) in ring_pass_fn(kv_and_dkv, mask, receive_buffers = (receive_kv_and_dkv, receive_mask), max_iters = max_ring_passes, ring_size = ring_size):
+        for (ring_rank, is_last), (
+            (kv_and_dkv, mask),
+            (receive_kv_and_dkv, receive_mask),
+        ) in ring_pass_fn(
+            kv_and_dkv,
+            mask,
+            receive_buffers=(receive_kv_and_dkv, receive_mask),
+            max_iters=max_ring_passes,
+            ring_size=ring_size,
+        ):
 
             kv, dk, dv = kv_and_dkv
 
             # reconstitute correct types for k, v, dk, dv
 
-            k, v = kv.chunk(2, dim = -1)
+            k, v = kv.chunk(2, dim=-1)
             k, v = k.view(k_dtype), v.view(v_dtype)
 
             # determine whether to do causal mask or not
@@ -708,24 +791,24 @@ class RingFlashAttentionCUDAFunction(Function):
                 raise NotImplementedError
 
                 ring_dq, ring_dk, ring_dv, *_ = _flash_attn_varlen_backward(
-                    dout = do,
-                    q = q,
-                    k = k,
-                    v = v,
-                    out = o,
-                    softmax_lse = lse,
-                    dq = torch.zeros_like(q),
-                    dk = torch.zeros_like(k),
-                    dv = torch.zeros_like(v),
-                    cu_seqlens_q = None,
-                    cu_seqlens_k = None,
-                    max_seqlen_q = None,
-                    max_seqlen_k = None,
-                    softmax_scale = softmax_scale,
-                    causal = False,
-                    window_size = (-1, -1),
-                    alibi_slopes = None,
-                    deterministic = False
+                    dout=do,
+                    q=q,
+                    k=k,
+                    v=v,
+                    out=o,
+                    softmax_lse=lse,
+                    dq=torch.zeros_like(q),
+                    dk=torch.zeros_like(k),
+                    dv=torch.zeros_like(v),
+                    cu_seqlens_q=None,
+                    cu_seqlens_k=None,
+                    max_seqlen_q=None,
+                    max_seqlen_k=None,
+                    softmax_scale=softmax_scale,
+                    causal=False,
+                    window_size=(-1, -1),
+                    alibi_slopes=None,
+                    deterministic=False,
                 )
 
             dq.add_(ring_dq)
@@ -746,7 +829,9 @@ class RingFlashAttentionCUDAFunction(Function):
 
         return dq, dk, dv, None, None, None, None, None, None, None
 
+
 ring_flash_attn_cuda_ = RingFlashAttentionCUDAFunction.apply
+
 
 @beartype
 def ring_flash_attn_cuda(
@@ -759,6 +844,6 @@ def ring_flash_attn_cuda(
     ring_reduce_col: bool = False,
     striped_ring_attn: bool = False,
     max_lookback_seq_len: Optional[int] = None,
-    ring_size: Optional[int] = None
+    ring_size: Optional[int] = None,
 ):
     return ring_flash_attn_cuda_(q, k, v, mask, causal, bucket_size, ring_reduce_col, striped_ring_attn, max_lookback_seq_len, ring_size)


### PR DESCRIPTION
---
`ring_flash_attn_cuda` was mistyped as `ring_flash_attention_cuda` in the import

EDIT: Changing this PR to draft as further changes are necessary, and it is not yet working with CUDA

---

### Description

This PR seeks to get the codebase running with cuda. We use a minimally modified version of `assert.py`, "`assert_cuda.py`", as a test file to test if the codebase can be run on 8 gpus. 
Note: you must specify the environment variable `CUDA_VISIBLE_DEVICES` eg:
```
CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 python assert_cuda.py
```

<details>
<summary><b>Environment info</b></summary>

running on a single node with 8x40GB A100s
```
absl-py==2.0.0
accelerate==0.23.0
aiohttp==3.9.1
aiosignal==1.3.1
annotated-types==0.6.0
anthropic==0.9.0
anyio==4.2.0
appdirs==1.4.4
asttokens==2.4.1
async-timeout==4.0.3
attrs==23.2.0
beartype==0.17.2
bitsandbytes==0.41.2.post2
cachetools==5.3.2
certifi==2023.11.17
chardet==5.2.0
charset-normalizer==3.3.2
chex==0.1.85
click==8.1.7
colorama==0.4.6
comm==0.2.1
contourpy==1.2.0
cycler==0.12.1
DataProperty==1.0.1
datasets==2.14.6
debugpy==1.8.0
decorator==5.1.1
deepspeed==0.12.2
dill==0.3.7
distro==1.9.0
docker-pycreds==0.4.0
docstring-parser==0.15
einops==0.7.0
einx==0.1.3
etils==1.5.2
evaluate==0.4.0
exceptiongroup==1.2.0
executing==2.0.1
fastapi==0.109.0
filelock==3.13.1
flash-attn==2.5.2
flax==0.7.0
fonttools==4.47.2
frozendict==2.4.0
frozenlist==1.4.1
fsspec==2023.10.0
gitdb==4.0.11
GitPython==3.1.41
google-auth==2.26.1
google-auth-oauthlib==1.2.0
grpcio==1.60.0
h11==0.14.0
hjson==3.1.0
httpcore==1.0.2
httpx==0.26.0
huggingface-hub==0.20.2
idna==3.6
importlib-metadata==7.0.1
importlib-resources==6.1.1
ipykernel==6.29.0
ipython==8.18.1
jax==0.4.25
jaxlib==0.4.25
jedi==0.19.1
Jinja2==3.1.2
joblib==1.3.2
jsonlines==4.0.0
jsonschema==4.20.0
jsonschema-specifications==2023.12.1
jupyter_client==8.6.0
jupyter_core==5.7.1
kiwisolver==1.4.5
lxml==5.1.0
Markdown==3.5.2
markdown-it-py==3.0.0
markdown2==2.4.12
MarkupSafe==2.1.3
matplotlib==3.8.2
matplotlib-inline==0.1.6
mbstrdecoder==1.1.3
mdurl==0.1.2
ml-dtypes==0.3.2
mpmath==1.3.0
msgpack==1.0.7
multidict==6.0.4
multiprocess==0.70.15
nest-asyncio==1.5.9
networkx==3.2.1
nh3==0.2.15
ninja==1.11.1.1
nltk==3.8.1
numexpr==2.8.8
numpy==1.26.3
nvidia-cublas-cu12==12.1.3.1
nvidia-cuda-cupti-cu12==12.1.105
nvidia-cuda-nvrtc-cu12==12.1.105
nvidia-cuda-runtime-cu12==12.1.105
nvidia-cudnn-cu12==8.9.2.26
nvidia-cufft-cu12==11.0.2.54
nvidia-curand-cu12==10.3.2.106
nvidia-cusolver-cu12==11.4.5.107
nvidia-cusparse-cu12==12.1.0.106
nvidia-nccl-cu12==2.18.1
nvidia-nvjitlink-cu12==12.3.101
nvidia-nvtx-cu12==12.1.105
oauthlib==3.2.2
openai==0.28.1
opt-einsum==3.3.0
optax==0.1.9
orbax-checkpoint==0.5.3
packaging==23.2
pandas==2.1.4
parso==0.8.3
pathvalidate==3.2.0
peft==0.7.1
pexpect==4.9.0
pillow==10.2.0
platformdirs==4.1.0
portalocker==2.8.2
prompt-toolkit==3.0.43
protobuf==3.20.2
psutil==5.9.7
ptyprocess==0.7.0
pure-eval==0.2.2
py-cpuinfo==9.0.0
pyarrow==14.0.2
pyasn1==0.5.1
pyasn1-modules==0.3.0
pybind11==2.11.1
pydantic==1.10.13
pydantic_core==2.14.6
Pygments==2.17.2
pynvml==11.5.0
pyparsing==3.1.1
pytablewriter==1.2.0
python-dateutil==2.8.2
pytz==2023.3.post1
PyYAML==6.0.1
pyzmq==25.1.2
ray==2.9.0
referencing==0.32.1
regex==2023.12.25
requests==2.31.0
requests-oauthlib==1.3.1
responses==0.18.0
rich==13.7.0
rouge-score==0.1.2
rpds-py==0.16.2
rsa==4.9
sacrebleu==2.4.0
safetensors==0.4.1
scikit-learn==1.3.2
scipy==1.11.4
seaborn==0.13.2
sentencepiece==0.1.99
sentry-sdk==1.39.2
setproctitle==1.3.3
shortuuid==1.0.11
shtab==1.6.5
six==1.16.0
smmap==5.0.1
sniffio==1.3.0
sqlitedict==2.1.0
stack-data==0.6.3
starlette==0.35.1
svgwrite==1.4.3
sympy==1.12
tabledata==1.3.3
tabulate==0.9.0
tcolorpy==0.1.4
tensorboard==2.15.1
tensorboard-data-server==0.7.2
tensorstore==0.1.53
threadpoolctl==3.2.0
tiktoken==0.5.2
tokenizers==0.15.0
toolz==0.12.1
torch==2.1.2
tornado==6.4
tqdm==4.66.1
tqdm-multiprocess==0.0.11
traitlets==5.14.1
transformers==4.36.2
triton==2.1.0
trl==0.7.7
typepy==1.3.2
typing_extensions==4.9.0
tyro==0.6.3
tzdata==2023.4
urllib3==2.1.0
uvicorn==0.25.0
wandb==0.16.2
wavedrom==2.0.3.post3
wcwidth==0.2.13
Werkzeug==3.0.1
xxhash==3.4.1
yarl==1.9.4
zipp==3.17.0
zstandard==0.22.0
```

</details>

### State of changes before rebase on 0.2.9

After some minor changes to get things kicked off (eg missing import, typos, ...), we have that the ring attention transformer forwards pass hangs in `send_and_receive_` on `dist.recv(receive_buffer, receive_from_rank)`, and we find that replacing the isend/irecv requests in send_and_receive_ with batched ones fixes this (see [the comment below](https://github.com/lucidrains/ring-attention-pytorch/pull/9#issuecomment-2000101513)).

With the batched request changed and turned on, the ring attention transformer fails in the flash attention backwards pass with:

```
File "/home/ubuntu/work/ring-attention-pytorch/ring_attention_pytorch/ring_flash_attention_cuda.py", line 759, in backward
    ring_dq, ring_dk, ring_dv, *_ = _flash_attn_backward(
  File "/home/ubuntu/work/ring_mlp/ringmlpvenv/lib/python3.9/site-packages/flash_attn/flash_attn_interface.py", line 133, in _flash_attn_backward
    dq, dk, dv, softmax_d, = flash_attn_cuda.bwd(
RuntimeError: out must have shape (batch_size, seqlen_q, num_heads, head_size)
```

When `striped_ring_attn=False` is set in `assert_cuda.py`, we find that the ring backwards pass returns from `_flash_attn_backward` succesfully, but hangs at an undetermined later point.

### State as of [5532b7b](https://github.com/lucidrains/ring-attention-pytorch/pull/9/commits/5532b7b32f25734027feb511f5cf6a21984829a7)

both striped and non-striped ring attention get through the computation but are not close in terms of forward pass outputs.
```
torch.allclose(ring_out, flash_out, atol=1e-6), "output is not the same"
> False
a = ring_out - flash_out
a.max()
> tensor(0.6748, grad_fn=<MaxBackward1>)
a.mean()
> tensor(0.0011, grad_fn=<MeanBackward0>)
```

However the gradients are close, with a max difference on the order of 0.0004
